### PR TITLE
Implement animation sharing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.{js,jsx}]
+indent_style = space
+indent_size = 2

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "npm run build && npm run lint && flow",
     "gh-pages": "NODE_ENV=production BASE_URL=webedit-react/ webpack",
-    "start": "BABEL_ENV=hot webpack-dev-server --host 0.0.0.0 --hot --inline --progress --history-api-fallbacck --content-base www",
+    "start": "BABEL_ENV=hot webpack-dev-server --host 0.0.0.0 --hot --inline --progress --history-api-fallback --content-base www",
     "dev": "webpack-dev-server --inline --progress --history-api-fallback --content-base www",
     "lint": "eslint src/**/*.js && eslint src/**/*.jsx",
     "build": "webpack"

--- a/src/Actions/animations.js
+++ b/src/Actions/animations.js
@@ -18,6 +18,8 @@ export const addNewAnimation = createAction('ADD_ANIMATION', (type: string) => (
   animation: { data: EMPTY_DATA, currentFrame: 0, frames: 1, length: 1 },
 }));
 
+export const addAnimation = createAction('ADD_ANIMATION', (animation: Animation) => animation);
+
 export const selectAnimation = createAction('SELECT_ANIMATION', (animation: Animation) => animation);
 
 export const updateAnimation = createAction('UPDATE_ANIMATION', (animation: Animation) => animation);

--- a/src/Components/AnimationInMenu.jsx
+++ b/src/Components/AnimationInMenu.jsx
@@ -44,7 +44,7 @@ export default class AnimationInMenu extends React.Component {
         primaryText={animation.name}
         secondaryText={(animation.type === 'pixel') ? t('animation.animation') : t('animation.text')}
         onTouchTap={this.selectAnimation}
-        style={selected && { backgroundColor: '#e0e0e0' }} />
+        style={selected ? { backgroundColor: '#e0e0e0' } : {}} />
     );
   }
 }

--- a/src/Components/App.jsx
+++ b/src/Components/App.jsx
@@ -47,11 +47,21 @@ reduxActions.createAction = (function(old) {
 }(reduxActions.createAction));
 
 const Webedit = require('./Webedit').default;
+const addAnimation = require('../Actions/animations').addAnimation;
 export default class App extends React.Component {
   static childContextTypes = {
     store: React.PropTypes.any,
   };
   getChildContext(): Object {
+    /* If an encoded animation is passed via the URL, try to decode and import
+     * it to the local application state
+     */
+    const encodedAnimation = this.props.params.encodedAnimation;
+    if (encodedAnimation) {
+      const decodedAnimation = JSON.parse(atob(encodedAnimation));
+      addAnimation(decodedAnimation);
+    }
+
     return {
       store,
     };

--- a/src/Components/App.jsx
+++ b/src/Components/App.jsx
@@ -56,7 +56,7 @@ export default class App extends React.Component {
     /* If an encoded animation is passed via the URL, try to decode and import
      * it to the local application state
      */
-    const encodedAnimation = this.props.params.encodedAnimation;
+    const encodedAnimation = this.props.location.query.s;
     if (encodedAnimation) {
       const decodedAnimation = JSON.parse(atob(encodedAnimation));
       addAnimation(decodedAnimation);

--- a/src/Components/RightMenu.jsx
+++ b/src/Components/RightMenu.jsx
@@ -71,6 +71,14 @@ export default class RightMenu extends React.Component {
       isOpen: false,
     });
   }
+  @autobind
+  share() {
+    const selectedAnimation = this.context.store.getState().selectedAnimation,
+          encodedAnimation = btoa(JSON.stringify(selectedAnimation)),
+          shareUrl = `/${encodedAnimation}`;
+
+    console.log(shareUrl);
+  }
   new() {
     reset();
   }
@@ -91,6 +99,7 @@ export default class RightMenu extends React.Component {
 
     return (
       <div style={style.wrap}>
+        <RaisedButton label={t('menu.share')} onClick={this.share} primary style={style.button}/>
         <RaisedButton label={t('menu.new')} onClick={this.new} primary style={style.button}/>
         <RaisedButton label={t('menu.transfer')} onClick={this.transfer} primary style={style.button}/>
         {/*<FlatButton label="Save" icon={<FontIcon className=" fa fa-floppy-o"/>}/>

--- a/src/Components/Webedit.jsx
+++ b/src/Components/Webedit.jsx
@@ -69,7 +69,7 @@ class Webedit extends React.Component {
             </Drawer>
             <Editor/>
           </div>
-      </div>
+        </div>
       </MuiThemeProvider>
     );
   }

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -30,7 +30,7 @@
     "addAnimation": "Neue Animation",
     "addText": "Neuer Text"
   },
-  "dialog": {
+  "transfer_dialog": {
     "cancel": "Abbrechen",
     "transfer": "Übertragen",
     "submit": "Übertragen",
@@ -39,5 +39,11 @@
     "instructions1": "Verbinde das Audio-Kabel mit deinem Computer und deiner BlinkenRocket",
     "instructions2": "Stelle die Lautstärke auf das Maxmimum!",
     "instructions3": "Drücke auf den Übertragen-Button"
+  },
+  "share_dialog": {
+    "title": "Animation teilen",
+    "instructions": "Gebe diesen Link weiter, um deine Animation zu teilen. Beim Aufrufen des Links wird diese automatisch importiert.",
+    "link": "klickediklick",
+    "close": "Schließen"
   }
 }

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -24,6 +24,7 @@
     "previousFrame": "Vorheriges Bild"
   },
   "menu": {
+    "share": "Teilen",
     "transfer": "Übertragen",
     "new": "Neu",
     "addAnimation": "Neue Animation",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -30,7 +30,7 @@
     "addAnimation": "New Animation",
     "addText": "New Text"
   },
-  "dialog": {
+  "transfer_dialog": {
     "cancel": "Cancel",
     "transfer": "Transfer",
     "submit": "Submit",
@@ -39,5 +39,11 @@
     "instructions1": "Connect the audio cable to the computer and your BlinkenRocket",
     "instructions2": "Turn up the volume to maximum!",
     "instructions3": "Click the transfer button"
+  },
+  "share_dialog": {
+    "title": "Share",
+    "instructions": "Using this link you can share your animation. It'll be automatically imported when opening the link.",
+    "link": "clickediclick",
+    "close": "Close"
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -24,6 +24,7 @@
     "previousFrame": "Previous Frame"
   },
   "menu": {
+    "share": "Share",
     "transfer": "Transfer",
     "new": "New",
     "addAnimation": "New Animation",

--- a/src/routes.js
+++ b/src/routes.js
@@ -6,5 +6,6 @@ import React from 'react';
 export default (
   <Router history={browserHistory}>
     <Route path={BASE_URL} component={App}/>
+    <Route path={`${BASE_URL}:encodedAnimation`} component={App}/>
   </Router>
 );

--- a/src/routes.js
+++ b/src/routes.js
@@ -6,6 +6,5 @@ import React from 'react';
 export default (
   <Router history={browserHistory}>
     <Route path={BASE_URL} component={App}/>
-    <Route path={`${BASE_URL}:encodedAnimation`} component={App}/>
   </Router>
 );


### PR DESCRIPTION
This pull request implements a big share button which opens a dialog containing a link to the current animation which can be shared. The animation is serialized using JSON and then made URL friendlier using base64 so there is no need for e.g. a database backend to store the shared animation. Furthermore all buttons inside the RightMenu component do have icons now.

Further improvements, not implemented right now:
- Add Facebook/Twitter/Whatever sharing buttons
- Compress the shared link using LZW or some similar simple string compression algorithm

Minor miscellaneous project improvements within this PR:
- Add an .editorconfig file to keep editors in sync
- Fix some indentation, some typos, …
