### PR TITLE
Upstream travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "6"
+install: npm install
+script: npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 node_js:
   - "6"
+branches:
+  only:
+    - gh-pages
+    - /.*/
 install: npm install
 script: npm run build

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# webedit-react
+# webedit-react  Blinkenrocket WebInterface
+
+[blinkenrocket.de](http://blinkenrocket.de/)
+
+## Quickstart
+
+System Setup
+
+* install NodeJS v6: https://nodejs.org/en/download/
+
+## Getting started with blinkenrocket-webedit-react
+
+    # Clone the Git repo:
+    git clone https://github.com/ChrisVeigl/blinkenrocket-webedit-react
+
+    # Install dependencies and build the project
+    blinkerocket-webedit-react
+    npm install
+    npm run build
+
+    # Run development server
+    npm run dev
+
+Now you can access the web interface via http://127.0.0.1:8080
+
+## Notes
+
+* if you want to test the interface from other devices use `webpack-dev-server --host <ip-adress-of-your-computer>`


### PR DESCRIPTION
Continuous Integration: Travis CI ([travis-ci.org](https://travis-ci.org))

When commits are pushed to the repository, travis performs `npm install` and `npm run build`, in order to check if it is actually building without errors.

To enable Travis CI for a repository, you need to perform these 2 steps: [travis-ci.org/getting_started](https://travis-ci.org/getting_started)

* Sign up at [travis-ci.org](https://travis-ci.org)
* Activate the repository on the travis-ci website

From then on, all pushes to Github will be tested by Travis CI.